### PR TITLE
Work in progress- HCSR04 sensor mounts

### DIFF
--- a/hcsr04_double_bracket.scad
+++ b/hcsr04_double_bracket.scad
@@ -1,0 +1,8 @@
+include <hcsr04_sensor_mount.scad>
+hcsr04_mount();
+//flange
+	//holes for mounting - m3.
+
+//Side panels at angle - 10 degrees?
+
+// Bolt down back plated - m3 bolts.

--- a/hcsr04_sensor_mount.scad
+++ b/hcsr04_sensor_mount.scad
@@ -1,0 +1,11 @@
+//hc-sr04 sensor mount plates with cutouts for transducers.
+// This is a 2d version - for extruding or otherwise projecting on your own designs.
+module hcsr04_mount() {
+	difference() {
+		square([45, 20], center=true);
+		translate([13.5, 0, 0]) circle(8);
+		translate([-13.5, 0, 0]) circle(8);
+	}
+}
+
+//hcsr04_mount();


### PR DESCRIPTION
Old attempt in OpenSCAD to make an HCSR04 sensor bracket.

Intention:
- A double bracket, front mounted, with two HC-SR04 slot pairs either side at angles.
- Designed to be 3D printed
- Bolted into place on a robot chassis - might need bolt slots - 3mm.
- Push through holes for the big cans - no other mount mechanisms for the sensors
- One part print - no glue

Out of scope
- No cable management

